### PR TITLE
feat(tag): add -d delete, -f force, and <commit> positional

### DIFF
--- a/src/commands/tag.js
+++ b/src/commands/tag.js
@@ -2,50 +2,111 @@ const fs = require('fs')
 const path = require('path')
 
 const { ensureRepo } = require('../core/repository')
-const getCurrentcommit = require('../helpers/getCurrentCommit')
+const getCurrentCommit = require('../helpers/getCurrentCommit')
 
 function getTagsPath() {
     return path.join(process.cwd(), '.mygit', 'refs', 'tags')
 }
 
-function createTag(name) {
-        const tagsPath =  getTagsPath()
-        if (!fs.existsSync(tagsPath)) {
-            fs.mkdirSync(tagsPath, {recursive: true})
-        }
+function getRefPath(kind, name) {
+    return path.join(process.cwd(), '.mygit', 'refs', kind, name)
+}
 
-        const tagPath = path.join(tagsPath, name)
-        if (fs.existsSync(tagPath)) {
-            console.error(`fatal: tag '${name}' already exists`)
-            process.exit(1)
-        }
+function isFullHash(s) {
+    return typeof s === 'string' && /^[0-9a-f]{40}$/.test(s)
+}
 
-        const commitHash = getCurrentcommit()
+function resolveCommit(ref) {
+    if (isFullHash(ref)) {
+        return ref
+    }
+    const branchPath = getRefPath('heads', ref)
+    if (fs.existsSync(branchPath)) {
+        return fs.readFileSync(branchPath, 'utf-8').trim()
+    }
+    const tagPath = getRefPath('tags', ref)
+    if (fs.existsSync(tagPath)) {
+        return fs.readFileSync(tagPath, 'utf-8').trim()
+    }
+    console.error(`fatal: '${ref}' is not a valid ref`)
+    process.exit(1)
+}
 
-        fs.writeFileSync(tagPath, commitHash + '\n')
+function createTag(name, commitHash, force) {
+    const tagsPath = getTagsPath()
+    if (!fs.existsSync(tagsPath)) {
+        fs.mkdirSync(tagsPath, { recursive: true })
+    }
+
+    const tagPath = path.join(tagsPath, name)
+    if (fs.existsSync(tagPath) && !force) {
+        console.error(`fatal: tag '${name}' already exists`)
+        process.exit(1)
+    }
+
+    fs.writeFileSync(tagPath, commitHash + '\n')
+}
+
+function deleteTag(name) {
+    const tagPath = path.join(getTagsPath(), name)
+    if (!fs.existsSync(tagPath)) {
+        console.error(`fatal: tag '${name}' not found`)
+        process.exit(1)
+    }
+    fs.unlinkSync(tagPath)
 }
 
 function listTags() {
     const tagsPath = getTagsPath()
-    if (!fs. existsSync(tagsPath)) {
+    if (!fs.existsSync(tagsPath)) {
         console.log('No tags found')
         return
     }
 
     const tags = fs.readdirSync(tagsPath)
+    if (tags.length === 0) {
+        console.log('No tags found')
+        return
+    }
     tags.sort().forEach(t => console.log(t))
+}
+
+function parseArgs(args) {
+    const opts = { delete: false, force: false }
+    const positional = []
+    for (const a of args) {
+        if (a === '-d' || a === '--delete') opts.delete = true
+        else if (a === '-f' || a === '--force') opts.force = true
+        else positional.push(a)
+    }
+    return { opts, positional }
 }
 
 function tag(args) {
     ensureRepo()
 
-    if (!args ||args.length === 0) {
+    const { opts, positional } = parseArgs(args || [])
+
+    if (opts.delete) {
+        if (positional.length === 0) {
+            console.error('fatal: tag name required for delete')
+            process.exit(1)
+        }
+        deleteTag(positional[0])
+        return
+    }
+
+    if (positional.length === 0) {
         listTags()
         return
     }
 
-    const tagName = args[0]
-    createTag(tagName)
+    const name = positional[0]
+    const commitHash = positional.length >= 2
+        ? resolveCommit(positional[1])
+        : getCurrentCommit()
+
+    createTag(name, commitHash, opts.force)
 }
 
 module.exports = tag

--- a/src/commands/tag.js
+++ b/src/commands/tag.js
@@ -3,6 +3,7 @@ const path = require('path')
 
 const { ensureRepo } = require('../core/repository')
 const getCurrentCommit = require('../helpers/getCurrentCommit')
+const readObject = require('../helpers/readObject')
 
 function getTagsPath() {
     return path.join(process.cwd(), '.mygit', 'refs', 'tags')
@@ -16,8 +17,47 @@ function isFullHash(s) {
     return typeof s === 'string' && /^[0-9a-f]{40}$/.test(s)
 }
 
+// validateTagName rejects names that would escape refs/tags via path
+// traversal or that don't form a usable single-segment ref. Mirrors a
+// subset of `git check-ref-format`: no embedded slashes, no leading
+// '-' or '.', no whitespace or NUL.
+function validateTagName(name) {
+    if (typeof name !== 'string' || name.length === 0) {
+        return 'tag name must be a non-empty string'
+    }
+    if (name.includes('/') || name.includes('\\')) {
+        return `invalid tag name '${name}': must not contain '/' or '\\'`
+    }
+    if (/[\s\0]/.test(name)) {
+        return `invalid tag name '${name}': must not contain whitespace or NUL`
+    }
+    if (name.startsWith('-') || name.startsWith('.')) {
+        return `invalid tag name '${name}': must not start with '-' or '.'`
+    }
+    return null
+}
+
+function ensureTagNameValid(name) {
+    const err = validateTagName(name)
+    if (err) {
+        console.error(`fatal: ${err}`)
+        process.exit(1)
+    }
+}
+
 function resolveCommit(ref) {
     if (isFullHash(ref)) {
+        let obj
+        try {
+            obj = readObject(ref)
+        } catch (e) {
+            console.error(`fatal: '${ref}' is not a valid ref`)
+            process.exit(1)
+        }
+        if (obj.type !== 'commit') {
+            console.error(`fatal: '${ref}' is a ${obj.type}, not a commit`)
+            process.exit(1)
+        }
         return ref
     }
     const branchPath = getRefPath('heads', ref)
@@ -33,6 +73,8 @@ function resolveCommit(ref) {
 }
 
 function createTag(name, commitHash, force) {
+    ensureTagNameValid(name)
+
     const tagsPath = getTagsPath()
     if (!fs.existsSync(tagsPath)) {
         fs.mkdirSync(tagsPath, { recursive: true })
@@ -48,6 +90,8 @@ function createTag(name, commitHash, force) {
 }
 
 function deleteTag(name) {
+    ensureTagNameValid(name)
+
     const tagPath = path.join(getTagsPath(), name)
     if (!fs.existsSync(tagPath)) {
         console.error(`fatal: tag '${name}' not found`)

--- a/src/commands/tag.js
+++ b/src/commands/tag.js
@@ -45,6 +45,13 @@ function ensureTagNameValid(name) {
     }
 }
 
+// isSimpleRefName allows the same set as a tag name: a single path segment
+// with no separators, no whitespace, no leading '-' / '.'. This prevents
+// '../../HEAD' from being treated as a branch / tag lookup.
+function isSimpleRefName(ref) {
+    return validateTagName(ref) === null
+}
+
 function resolveCommit(ref) {
     if (isFullHash(ref)) {
         let obj
@@ -59,6 +66,10 @@ function resolveCommit(ref) {
             process.exit(1)
         }
         return ref
+    }
+    if (!isSimpleRefName(ref)) {
+        console.error(`fatal: '${ref}' is not a valid ref`)
+        process.exit(1)
     }
     const branchPath = getRefPath('heads', ref)
     if (fs.existsSync(branchPath)) {

--- a/src/utils/displayHelp.js
+++ b/src/utils/displayHelp.js
@@ -140,9 +140,14 @@ function addHelp() {
 
 function tagHelp() {
     console.log('')
-    console.log('   tag'.padEnd(16) + 'List existing tags or create tags')
-    console.log('   mygit tag'.padEnd(16) + 'List all tags')
-    console.log('   mygit tag <name>'.padEnd(16) + 'Create a new tag')
+    console.log('   tag'.padEnd(16) + 'List existing tags, create or delete tags\n')
+    console.log('   mygit tag                       List all tags')
+    console.log('   mygit tag <name>                Create a tag at HEAD')
+    console.log('   mygit tag <name> <commit>       Create a tag at <commit>')
+    console.log('   mygit tag -f <name> [<commit>]  Force-overwrite an existing tag')
+    console.log('   mygit tag -d <name>             Delete a tag')
+    console.log('')
+    console.log('   <commit> may be a 40-character hash, a branch name, or another tag name.')
     console.log('')
 }
 

--- a/tests/tag.test.js
+++ b/tests/tag.test.js
@@ -1,0 +1,183 @@
+const fs = require('fs')
+const path = require('path')
+const test = require('node:test')
+const assert = require('node:assert')
+const zlib = require('zlib')
+const crypto = require('crypto')
+
+const { setupRepo, cleanupRepo, baseDir } = require('./helpers/setup')
+const captureOutput = require('./helpers/captureOutput')
+const tagCmd = require('../src/commands/tag')
+
+test.beforeEach(() => {
+    setupRepo()
+
+    fs.mkdirSync(
+        path.join(baseDir, '.mygit', 'refs', 'heads'),
+        { recursive: true }
+    )
+
+    fs.writeFileSync(
+        path.join(baseDir, '.mygit', 'HEAD'),
+        'ref: refs/heads/main'
+    )
+})
+test.afterEach(cleanupRepo)
+
+// HELPERS
+
+function writeCommit(content) {
+    const body = Buffer.from(content)
+    const header = Buffer.from(`commit ${body.length}\0`)
+    const store = Buffer.concat([header, body])
+    const hash = crypto.createHash('sha1').update(store).digest('hex')
+
+    const dir = path.join(baseDir, '.mygit', 'objects', hash.slice(0, 2))
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(path.join(dir, hash.slice(2)), zlib.deflateSync(store))
+    return hash
+}
+
+function seedHead(hash) {
+    fs.writeFileSync(
+        path.join(baseDir, '.mygit', 'refs', 'heads', 'main'),
+        hash
+    )
+}
+
+function makeCommit(message) {
+    const hash = writeCommit(
+`tree abc123
+author Test <test@example.com> 1710000000 +0000
+committer Test <test@example.com> 1710000000 +0000
+
+${message}`
+    )
+    return hash
+}
+
+function readTag(name) {
+    return fs
+        .readFileSync(path.join(baseDir, '.mygit', 'refs', 'tags', name), 'utf-8')
+        .trim()
+}
+
+console.log('\nTESTING TAG\n')
+
+test('tag <name> creates a tag at HEAD', () => {
+    const head = makeCommit('first')
+    seedHead(head)
+
+    captureOutput(() => tagCmd(['v1']))
+
+    assert.strictEqual(readTag('v1'), head)
+})
+
+test('tag (no args) lists tags', () => {
+    const head = makeCommit('first')
+    seedHead(head)
+    captureOutput(() => tagCmd(['v1']))
+    captureOutput(() => tagCmd(['v2']))
+
+    const { output } = captureOutput(() => tagCmd([]))
+
+    assert.match(output, /^v1$/m)
+    assert.match(output, /^v2$/m)
+})
+
+test('tag (no tags dir) reports no tags', () => {
+    const { output } = captureOutput(() => tagCmd([]))
+    assert.match(output, /No tags found/)
+})
+
+test('tag <name> twice without -f errors and does not rewrite', () => {
+    const first = makeCommit('first')
+    seedHead(first)
+    captureOutput(() => tagCmd(['v1']))
+    const before = readTag('v1')
+
+    const second = makeCommit('second')
+    seedHead(second)
+    const { output, exitCode } = captureOutput(() => tagCmd(['v1']))
+
+    assert.strictEqual(exitCode, 1)
+    assert.match(output, /already exists/)
+    assert.strictEqual(readTag('v1'), before)
+})
+
+test('tag -f <name> overwrites an existing tag', () => {
+    const first = makeCommit('first')
+    seedHead(first)
+    captureOutput(() => tagCmd(['v1']))
+
+    const second = makeCommit('second')
+    seedHead(second)
+    captureOutput(() => tagCmd(['-f', 'v1']))
+
+    assert.strictEqual(readTag('v1'), second)
+})
+
+test('tag <name> <commit-hash> creates the tag at that commit', () => {
+    const head = makeCommit('head commit')
+    seedHead(head)
+    const target = makeCommit('target commit')
+
+    captureOutput(() => tagCmd(['v-target', target]))
+
+    assert.strictEqual(readTag('v-target'), target)
+})
+
+test('tag <name> <branch> resolves the branch ref', () => {
+    const head = makeCommit('first')
+    seedHead(head)
+    const otherCommit = makeCommit('feature commit')
+    fs.writeFileSync(
+        path.join(baseDir, '.mygit', 'refs', 'heads', 'feature'),
+        otherCommit
+    )
+
+    captureOutput(() => tagCmd(['v-feature', 'feature']))
+
+    assert.strictEqual(readTag('v-feature'), otherCommit)
+})
+
+test('tag -d <name> deletes the tag', () => {
+    const head = makeCommit('first')
+    seedHead(head)
+    captureOutput(() => tagCmd(['v1']))
+    assert.ok(
+        fs.existsSync(path.join(baseDir, '.mygit', 'refs', 'tags', 'v1')),
+    )
+
+    captureOutput(() => tagCmd(['-d', 'v1']))
+
+    assert.strictEqual(
+        fs.existsSync(path.join(baseDir, '.mygit', 'refs', 'tags', 'v1')),
+        false,
+    )
+})
+
+test('tag -d on missing tag errors', () => {
+    const { output, exitCode } = captureOutput(() => tagCmd(['-d', 'never']))
+    assert.strictEqual(exitCode, 1)
+    assert.match(output, /not found/)
+})
+
+test('tag <name> <bogus-ref> errors', () => {
+    const head = makeCommit('first')
+    seedHead(head)
+    const { output, exitCode } = captureOutput(() => tagCmd(['v1', 'no-such-ref']))
+    assert.strictEqual(exitCode, 1)
+    assert.match(output, /not a valid ref/)
+})
+
+test('tag --delete <name> long form deletes', () => {
+    const head = makeCommit('first')
+    seedHead(head)
+    captureOutput(() => tagCmd(['v1']))
+    captureOutput(() => tagCmd(['--delete', 'v1']))
+    assert.strictEqual(
+        fs.existsSync(path.join(baseDir, '.mygit', 'refs', 'tags', 'v1')),
+        false,
+    )
+})

--- a/tests/tag.test.js
+++ b/tests/tag.test.js
@@ -171,6 +171,57 @@ test('tag <name> <bogus-ref> errors', () => {
     assert.match(output, /not a valid ref/)
 })
 
+test('tag <name> <bogus-hash> errors when the object does not exist', () => {
+    const head = makeCommit('first')
+    seedHead(head)
+    const fakeHash = 'd'.repeat(40)
+    const { output, exitCode } = captureOutput(() => tagCmd(['v1', fakeHash]))
+    assert.strictEqual(exitCode, 1)
+    assert.match(output, /not a valid ref/)
+})
+
+test('tag <name> <tree-hash> rejects non-commit objects', () => {
+    const head = makeCommit('first')
+    seedHead(head)
+    // Write a tree object directly so we have a valid hash that isn't a commit.
+    const treeBody = Buffer.from('100644 blob abc123\tfile.txt')
+    const treeHeader = Buffer.from(`tree ${treeBody.length}\0`)
+    const store = Buffer.concat([treeHeader, treeBody])
+    const treeHash = crypto.createHash('sha1').update(store).digest('hex')
+    const dir = path.join(baseDir, '.mygit', 'objects', treeHash.slice(0, 2))
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(path.join(dir, treeHash.slice(2)), zlib.deflateSync(store))
+
+    const { output, exitCode } = captureOutput(() => tagCmd(['v1', treeHash]))
+    assert.strictEqual(exitCode, 1)
+    assert.match(output, /is a tree, not a commit/)
+})
+
+test('tag rejects names with path separators', () => {
+    const head = makeCommit('first')
+    seedHead(head)
+    // Pre-existing branch ref we must NOT be able to overwrite via tag -f.
+    const branchPath = path.join(baseDir, '.mygit', 'refs', 'heads', 'main')
+    const original = fs.readFileSync(branchPath, 'utf-8')
+
+    const { output, exitCode } = captureOutput(
+        () => tagCmd(['-f', '../heads/main']),
+    )
+
+    assert.strictEqual(exitCode, 1)
+    assert.match(output, /must not contain '\/'/)
+    // Branch ref untouched.
+    assert.strictEqual(fs.readFileSync(branchPath, 'utf-8'), original)
+})
+
+test('tag rejects delete with path separators', () => {
+    const { output, exitCode } = captureOutput(
+        () => tagCmd(['-d', '../heads/main']),
+    )
+    assert.strictEqual(exitCode, 1)
+    assert.match(output, /must not contain '\/'/)
+})
+
 test('tag --delete <name> long form deletes', () => {
     const head = makeCommit('first')
     seedHead(head)

--- a/tests/tag.test.js
+++ b/tests/tag.test.js
@@ -214,6 +214,23 @@ test('tag rejects names with path separators', () => {
     assert.strictEqual(fs.readFileSync(branchPath, 'utf-8'), original)
 })
 
+test('tag <name> with traversal in ref arg is rejected', () => {
+    const head = makeCommit('first')
+    seedHead(head)
+
+    const { output, exitCode } = captureOutput(
+        () => tagCmd(['v1', '../../HEAD']),
+    )
+
+    assert.strictEqual(exitCode, 1)
+    assert.match(output, /not a valid ref/)
+    // Tag must not have been written.
+    assert.strictEqual(
+        fs.existsSync(path.join(baseDir, '.mygit', 'refs', 'tags', 'v1')),
+        false,
+    )
+})
+
 test('tag rejects delete with path separators', () => {
     const { output, exitCode } = captureOutput(
         () => tagCmd(['-d', '../heads/main']),


### PR DESCRIPTION
## Summary

Extends `mygit tag` from create-and-list-only to the three real-`git tag` features that exercise the existing `refs/heads/`, `refs/tags/`, and object-store helpers in this repo. Adds 79-test coverage including the original cases plus path-traversal and bogus-hash regressions.

## Changes

- `mygit tag -d <name>` / `--delete`: deletes a lightweight tag, errors when the tag isn't present.
- `mygit tag -f <name> [<commit>]` / `--force`: overwrites an existing tag instead of erroring.
- `mygit tag <name> <commit>`: second positional accepts a 40-hex commit hash, a branch name (resolved via `refs/heads/<name>`), or a tag name (resolved via `refs/tags/<name>`).

Plus three correctness guards added in response to a `codex review` pass on the diff:

- 40-hex-character hashes go through `readObject` and must resolve to a `commit` — a typo that names a non-existent or non-commit object now errors instead of silently writing a dangling tag.
- Tag names get a `validateTagName` check that rejects embedded slashes, leading `-` / `.`, whitespace, and NUL — so `tag -f ../heads/main` and `tag -d ../heads/main` can't escape `refs/tags/` to overwrite or delete other refs.
- The `<commit>` positional, when treated as a branch/tag ref, runs through the same single-segment validation — so `tag v ../../HEAD` can't read `.mygit/HEAD` into the tag.

## Why this matters

Issue #11 asked for "as many features as possible and as similar as possible to the original `git tag` command." `-d`, `-f`, and `<commit>` are the three flags any real workflow hits within the first day, and they all fit the existing helpers (`getCurrentCommit`, `readObject`, `refs/heads/`). I deliberately stopped short of annotated tags (`-a` / `-m`), tag signing, and glob list patterns because those need new object types and a tag-message store, which is a much bigger PR; happy to follow up if you'd like.

The validation work in commits 2 and 3 is the bigger lift in lines: lightweight tags are just files, so anything that writes a path joined from user input is one `..` away from corrupting the repo. Locking down the name and ref inputs costs ~50 lines and removes that whole class of attack from the new surface.

## Test plan

- `npm test` — 79 tests, all green. New `TESTING TAG` block has 16 cases covering: list / create / no-tags-dir / already-exists / `-f` overwrite / commit-hash target / branch target / `-d` delete / `-d` missing / bogus ref name / bogus 40-hex hash / non-commit object hash / `-f` traversal escape / `<commit>` traversal escape / `-d` traversal escape / `--delete` long form.
- Manual sanity: `node bin/mygit.js init && node bin/mygit.js tag v1 && node bin/mygit.js tag` lists v1, then `node bin/mygit.js tag -d v1` removes it.

Closes #11

This contribution was developed with AI assistance (Codex).
