### PR TITLE
docs: add JSDoc to hashObjectContent helper

### DIFF
--- a/src/helpers/hashObjectContent.js
+++ b/src/helpers/hashObjectContent.js
@@ -3,6 +3,34 @@ const path = require('path')
 const crypto = require('crypto')
 const zlib = require('zlib')
 
+/**
+ * hashObjectContent - hash and store a Git-style loose object.
+ *
+ * Builds the canonical Git object format (`<type> <length>\0<content>`),
+ * computes its SHA-1, and writes a zlib-deflated copy to
+ * `.mygit/objects/<first-2-of-hash>/<rest-of-hash>`. Existing objects on
+ * disk are never overwritten because Git loose objects are
+ * content-addressed: the same payload produces the same hash, so a
+ * second write would only re-encode identical bytes.
+ *
+ * Side effects: creates the `.mygit/objects/<xx>/` directory if missing,
+ * writes the compressed object file if it does not already exist.
+ *
+ * @param {Buffer|string} content - raw object payload (file bytes for a
+ *   blob, the serialized tree entries for a tree, the commit text for a
+ *   commit). When a `string` is passed it is wrapped in a `Buffer` via
+ *   `Buffer.concat`, so callers may pass either.
+ * @param {'blob'|'tree'|'commit'|'tag'} [type='blob'] - Git object type
+ *   that becomes the header prefix. Defaults to `'blob'`.
+ * @returns {string} the 40-character hex SHA-1 of the canonical
+ *   `<type> <length>\0<content>` payload - the stable identifier
+ *   under `.mygit/objects/`.
+ * @throws {TypeError} when `content.length` is unreadable (e.g. a
+ *   non-Buffer, non-string value), via `Buffer.concat`.
+ * @throws {Error} when the underlying filesystem write fails (permission
+ *   denied, full disk, etc.) - the failure surfaces from
+ *   `fs.mkdirSync` or `fs.writeFileSync`.
+ */
 function hashObjectContent(content, type='blob') {
     // Hash and store content as a blob
 


### PR DESCRIPTION
## Summary

Closes #16.

Adds a structured JSDoc block to `src/helpers/hashObjectContent.js`. The block:

- Summarises what the function does (build the canonical Git `<type> <length>\0<content>` payload, hash it, write a zlib-deflated copy under `.mygit/objects/<xx>/<rest>`).
- Calls out the side effects (`mkdirSync` + `writeFileSync`) so callers know the function is not pure.
- Documents `@param content` as `Buffer|string` (the existing `Buffer.concat([Buffer.from(header), content])` accepts either) and `@param type` with the four valid Git object kinds.
- Documents the `@returns` as the 40-character hex SHA-1.
- Documents the `@throws` paths: `TypeError` from `Buffer.concat` on bad input shapes, and a generic `Error` pass-through from `fs.mkdirSync` / `fs.writeFileSync` on I/O failure.

Mirrors the JSDoc style already used in `src/core/myersDiff.js` (block comment, `@param`, `@returns`, prose summary above the tags).

## Files

- `src/helpers/hashObjectContent.js` (+29 / -1) - JSDoc block added above the function declaration. No behavior change.

## Acceptance criteria (from the issue)

- [x] Add clear, structured JSDoc comments
- [x] Include parameter types and descriptions
- [x] Document return values and exceptions
- [x] Update `src/helpers/hashObjectContent.js` with full documentation
- [ ] Verify JSDoc renders correctly in IDE tooltips (manual check by maintainer in their IDE - VSCode TS server / WebStorm both render JSDoc from `@param` / `@returns` / `@throws` tags directly)

## Test plan

- [x] `node -e "require('./src/helpers/hashObjectContent.js')"` clean.
- [x] No behavior change.
- [x] Style matches existing JSDoc in `src/core/myersDiff.js`.