### PR TITLE
test(commit-tree): add commit-tree command tests

### DIFF
--- a/tests/commit-tree.test.js
+++ b/tests/commit-tree.test.js
@@ -1,0 +1,175 @@
+const test = require('node:test')
+const assert = require('node:assert')
+const fs = require('fs')
+const path = require('path')
+const zlib = require('zlib')
+
+const commitTree = require('../src/commands/commit-tree')
+const writeTree = require('../src/commands/write-tree')
+const { setupRepo, cleanupRepo, baseDir } = require('./helpers/setup')
+
+test.beforeEach(setupRepo)
+test.afterEach(cleanupRepo)
+
+// HELPERS
+function readObject(hash) {
+    const objPath = path.join(baseDir, '.mygit', 'objects', hash.slice(0, 2), hash.slice(2))
+
+    const compressed = fs.readFileSync(objPath)
+    const decompressed = zlib.inflateSync(compressed)
+
+    const nullIndex = decompressed.indexOf(0)
+
+    return {
+        header: decompressed.slice(0, nullIndex).toString(),
+        content: decompressed.slice(nullIndex + 1)
+    }
+}
+
+function objectPath(hash) {
+    return path.join(baseDir, '.mygit', 'objects', hash.slice(0, 2), hash.slice(2))
+}
+
+function setAuthorEnv(t, name, email) {
+    const originalName = process.env.MYGIT_AUTHOR_NAME
+    const originalEmail = process.env.MYGIT_AUTHOR_EMAIL
+
+    process.env.MYGIT_AUTHOR_NAME = name
+    process.env.MYGIT_AUTHOR_EMAIL = email
+
+    t.after(() => {
+        if (originalName === undefined) {
+            delete process.env.MYGIT_AUTHOR_NAME
+        } else {
+            process.env.MYGIT_AUTHOR_NAME = originalName
+        }
+
+        if (originalEmail === undefined) {
+            delete process.env.MYGIT_AUTHOR_EMAIL
+        } else {
+            process.env.MYGIT_AUTHOR_EMAIL = originalEmail
+        }
+    })
+}
+
+function captureOutput(fn) {
+    const originalLog = console.log
+    const originalError = console.error
+    const originalExit = process.exit
+    let output = []
+    let exitCode = null
+
+    console.log = (...args) => {
+        output.push(args.join(' '))
+    }
+    console.error = (...args) => {
+        output.push(args.join(' '))
+    }
+    process.exit = (code) => {
+        exitCode = code
+        throw new Error(`EXIT ${code}`)
+    }
+
+    try {
+        fn()
+    } catch (err) {
+        if (!err.message || !err.message.includes('EXIT')) {
+            throw err
+        }
+    } finally {
+        console.log = originalLog
+        console.error = originalError
+        process.exit = originalExit
+    }
+
+    return { output: output.join('\n'), exitCode }
+}
+
+// ______TESTS______
+
+console.log('\nTESTING COMMIT-TREE\n')
+
+test('commit-tree creates a commit object without a parent', (t) => {
+    setAuthorEnv(t, 'Test Author', 'test@example.com')
+    fs.writeFileSync('hello.txt', 'hello world')
+
+    const treeHash = writeTree()
+    const commitHash = commitTree(treeHash, 'first commit')
+
+    assert.match(commitHash, /^[0-9a-f]{40}$/)
+
+    const obj = readObject(commitHash)
+    const body = obj.content.toString()
+
+    assert.match(obj.header, /^commit \d+$/)
+    assert.ok(body.includes(`tree ${treeHash}\n`))
+    assert.match(body, /author Test Author <test@example\.com> \d+ [+-]\d{4}\n/)
+    assert.match(body, /committer Test Author <test@example\.com> \d+ [+-]\d{4}\n/)
+    assert.strictEqual(body.endsWith('\nfirst commit\n'), true)
+})
+
+test('commit-tree creates a commit object with a parent', (t) => {
+    setAuthorEnv(t, 'Parent Author', 'parent@example.com')
+    fs.writeFileSync('file.txt', 'first')
+
+    const firstTreeHash = writeTree()
+    const firstCommitHash = commitTree(firstTreeHash, 'first')
+
+    fs.writeFileSync('file.txt', 'second')
+
+    const secondTreeHash = writeTree()
+    const secondCommitHash = commitTree(secondTreeHash, 'second', firstCommitHash)
+
+    assert.match(secondCommitHash, /^[0-9a-f]{40}$/)
+
+    const obj = readObject(secondCommitHash)
+    const body = obj.content.toString()
+    const lines = body.split('\n')
+
+    assert.strictEqual(lines[0], `tree ${secondTreeHash}`)
+    assert.strictEqual(lines[1], `parent ${firstCommitHash}`)
+    assert.strictEqual(body.endsWith('\nsecond\n'), true)
+})
+
+test('commit-tree shows error when tree hash is missing', () => {
+    const result = captureOutput(() => commitTree(null, 'message'))
+
+    assert.strictEqual(result.exitCode, 1)
+    assert.match(result.output, /tree hash required/)
+})
+
+test('commit-tree shows error when message is missing', () => {
+    const treeHash = 'a'.repeat(40)
+    const result = captureOutput(() => commitTree(treeHash))
+
+    assert.strictEqual(result.exitCode, 1)
+    assert.match(result.output, /commit message required/)
+})
+
+test('commit-tree uses MYGIT_AUTHOR_NAME and MYGIT_AUTHOR_EMAIL', (t) => {
+    setAuthorEnv(t, 'Env Author', 'env@example.com')
+    fs.writeFileSync('env.txt', 'env')
+
+    const treeHash = writeTree()
+    const commitHash = commitTree(treeHash, 'env test')
+    const obj = readObject(commitHash)
+    const body = obj.content.toString()
+
+    assert.match(body, /author Env Author <env@example\.com> \d+ [+-]\d{4}\n/)
+    assert.match(body, /committer Env Author <env@example\.com> \d+ [+-]\d{4}\n/)
+    assert.doesNotMatch(body, /Leonardo Garzon/)
+    assert.doesNotMatch(body, /example@gmail\.com/)
+})
+
+test('commit-tree stores the commit object and reuses the same hash for same input', (t) => {
+    setAuthorEnv(t, 'Stable Author', 'stable@example.com')
+    t.mock.method(Date, 'now', () => 1700000000000)
+    fs.writeFileSync('stable.txt', 'stable')
+
+    const treeHash = writeTree()
+    const commitHash1 = commitTree(treeHash, 'stable commit')
+    const commitHash2 = commitTree(treeHash, 'stable commit')
+
+    assert.strictEqual(commitHash1, commitHash2)
+    assert.strictEqual(fs.existsSync(objectPath(commitHash1)), true)
+})


### PR DESCRIPTION
Closes #3.

Adds `tests/commit-tree.test.js` mirroring the existing `tests/write-tree.test.js` template (`node:test` + `node:assert`, `setupRepo` / `cleanupRepo`, banner `console.log`).

Six test cases cover both the on-disk object writes and the validation/CLI-output paths:

1. commits a tree without a parent — asserts the returned 40-char SHA, inflates the object, checks header + tree/author/committer/message lines.
2. commits with a parent — second call passes a parent hash and the inflated body has a `parent <hash>` line between tree and author.
3. errors when tree hash is missing — captures `process.exit(1)` + `tree hash required` on stderr.
4. errors when message is missing — same shape, `commit message required`.
5. honors `MYGIT_AUTHOR_NAME` / `MYGIT_AUTHOR_EMAIL` — env-pinned author/committer lines instead of the defaults.
6. stores the object on disk and is content-addressable — same input replays produce the same hash and the file at `.mygit/objects/<hh>/<rest>` exists.

Verification

- `node --test tests/commit-tree.test.js` — 6/6 pass.
- The new file does not depend on the project's `tests/helpers/run` (which shells out to a `mygit` binary on PATH and is not directly portable).