### PR TITLE
fix(status): don't apply .mygitignore to tracked files

### DIFF
--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -33,7 +33,7 @@ function readTree(treeHash, prefix='') {
     return files
 }
 
-function getWorkingDirectoryFiles(baseDir = process.cwd(), currentDir = process.cwd(), mygitignorePatterns = null) {
+function getWorkingDirectoryFiles(baseDir = process.cwd(), currentDir = process.cwd(), mygitignorePatterns = null, indexEntries = {}) {
     // ─── Get all files in working directory with their hashes ───────────────
     // Returns: { 'path/to/file.txt': 'computed-hash', ... }
 
@@ -55,14 +55,14 @@ function getWorkingDirectoryFiles(baseDir = process.cwd(), currentDir = process.
         const stats = fs.statSync(fullPath)
         const relativePath = path.relative(baseDir, fullPath).split(path.sep).join('/');
 
-        if (isIgnored(relativePath, mygitignorePatterns)) {
+        if (isIgnored(relativePath, mygitignorePatterns) && !indexEntries[relativePath]) {
             continue
         }
 
 
         if (stats.isDirectory()) {
             // Recurse into sub directoru
-            const subfiles = getWorkingDirectoryFiles(baseDir, fullPath, mygitignorePatterns)
+            const subfiles = getWorkingDirectoryFiles(baseDir, fullPath, mygitignorePatterns, indexEntries)
             Object.assign(files, subfiles)
         } else if (stats.isFile()) {
             // Hash the file to compare with commited version
@@ -101,7 +101,7 @@ function status() {
 
     const currentCommit = getCurrentCommit()
     const index = readIndex()
-    const workingFiles = getWorkingDirectoryFiles()
+    const workingFiles = getWorkingDirectoryFiles(process.cwd(), process.cwd(), null, index.entries)
 
     // 4. Handle case: no commits yet
     if (!currentCommit) {
@@ -291,4 +291,3 @@ function status() {
 }
 
 module.exports = status
-

--- a/tests/status.test.js
+++ b/tests/status.test.js
@@ -52,6 +52,19 @@ test('status reports clean working tree after commit', () => {
     assert.match(output, /nothing to commit, working tree clean/i)
 })
 
+test('status shows tracked file even when in .mygitignore', () => {
+    const filePath = path.join(baseDir, 'text.txt')
+    fs.writeFileSync(filePath, 'hello')
+
+    run(`mygit add text.txt`)
+    run(`mygit commit -m "initial commit"`)
+
+    fs.writeFileSync(path.join(baseDir, '.mygitignore'), 'text.txt')
+
+    const output = run('mygit status')
+    assert.doesNotMatch(output, /deleted:\s+text\.txt/i)
+})
+
 // TEST STAGED MODIFIED FILE
 test('status shows staged modified files', () => {
     const filePath = path.join(baseDir, 'modified.txt')


### PR DESCRIPTION
## Summary

Fixes #24. `mygit status` was reporting tracked files as deleted when they appeared in `.mygitignore`. The root cause: `getWorkingDirectoryFiles` filtered the working tree by `.mygitignore` without consulting the index, so tracked-and-now-ignored files were silently dropped. The status comparison loop then concluded those files had been removed from the working tree.

## Why this matters

The reproduction in the issue shows the bug clearly: stage `text.txt`, then add `text.txt` to `.mygitignore`, and `mygit status` reports both `new file: text.txt` (from the index) and `deleted: text.txt` (from the missing working-tree entry). Real git's behaviour is that once a file is tracked, `.gitignore` no longer hides it from `git status`, `git diff`, or `git add`.

I traced the path through `src/commands/status.js`: the offending check is at line 58, `if (isIgnored(relativePath, mygitignorePatterns)) continue;`, inside `getWorkingDirectoryFiles`. The status function (line 104) reads the index unconditionally but never passes it down to the working-tree walker.

I also checked the other commands the issue mentions:

- `src/commands/add.js` calls `isIgnored` only inside `traverse()` (the `mygit add .` / directory path). Real git's `git add .` does NOT re-add tracked-but-newly-ignored files, so the existing behaviour matches and no change is needed there.
- `src/helpers/getTreeFiles.js` accepts `mygitignorePatterns`, but `src/commands/diff.js` always calls it without that argument (default `null` at line 18). Diff is unaffected.

So the fix is scoped to `getWorkingDirectoryFiles`.

## Changes

- `src/commands/status.js`: add an `indexEntries = {}` parameter to `getWorkingDirectoryFiles`, skip the `isIgnored` check when the path is in the index, and pass `index.entries` from the `status()` call site (and recursively into subdirectories).
- `tests/status.test.js`: add a regression test that commits `text.txt`, adds it to `.mygitignore`, and asserts `status` does NOT print a `deleted: text.txt` line.

## Testing

- `npm test` — 113 tests pass (existing 112 + 1 new regression test).
- Manually reproduced the scenario from the issue against the patched binary; the spurious `deleted: text.txt` line is gone.

Fixes #24
