### PR TITLE
docs(commands): add JSDoc to main function of each command file

### DIFF
--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -132,6 +132,12 @@ function addDirectory(dirPath) {
     return addedFiles
 }
 
+/**
+ * Adds files or directories to the index after hashing their current content.
+ * The special "." argument recursively stages files from the current directory, respecting mygitignore rules.
+ * @param {string[]} args - Paths or directory patterns to add to the index
+ * @throws {Error} If the current directory is not a mygit repository
+ */
 function add(args) {
     // 1. Check if in a mygit repositiry 
     ensureRepo()
@@ -170,4 +176,3 @@ function add(args) {
 }
 
 module.exports = add
-

--- a/src/commands/branch.js
+++ b/src/commands/branch.js
@@ -169,6 +169,12 @@ function deleteBranch(branchName, force=false) {
 
 // MAIN FUNCTION TO HANDLE THE BRANCH COMMAND
 
+/**
+ * Lists branches, creates a branch at the current commit, or deletes an existing branch.
+ * Supports verbose listing and delete flags while protecting the checked-out branch from deletion.
+ * @param {string[]} [args=[]] - Branch options, flags, or the branch name to create
+ * @throws {Error} If the repository is missing, an option is invalid, or branch creation/deletion cannot proceed
+ */
 function branch(args=[]) {
     // 1. Check if we're in a mygit repository
     const mygitDir = path.join(process.cwd(), '.mygit')

--- a/src/commands/cat-file.js
+++ b/src/commands/cat-file.js
@@ -35,6 +35,13 @@ function prettyPrint(type, content) {
     }
 }
 
+/**
+ * Reads an object from the object database and prints its type, size, or pretty content.
+ * Short hash prefixes are resolved before the object is loaded.
+ * @param {string} flags - Display mode: -t for type, -s for size, or -p for pretty content
+ * @param {string} hash - Full object hash or unique hash prefix to inspect
+ * @throws {Error} If arguments are missing, the hash is invalid or ambiguous, or the mode is unknown
+ */
 function catFile(flags, hash) {
     // 1. Validate inputs
 

--- a/src/commands/checkout.js
+++ b/src/commands/checkout.js
@@ -95,6 +95,12 @@ function updateWorkingDirectory(targetFiles) {
     }
 }
 
+/**
+ * Switches HEAD and the working directory to another branch.
+ * With -b, creates the branch at the current commit before checking it out.
+ * @param {string[]} args - Checkout arguments, optionally including -b followed by a branch name
+ * @throws {Error} If the repository, branch name, commit, tree, or working directory update is invalid
+ */
 function checkout(args) {
 
     // --1. Check if you are in a mygit repo

--- a/src/commands/commit-tree.js
+++ b/src/commands/commit-tree.js
@@ -31,6 +31,15 @@ function hashObjectContent(content, type='blob') {
     return hash
 }
 
+/**
+ * Builds and stores a commit object for a tree, including author metadata and optional parent commits.
+ * Returns the SHA-1 hash of the newly stored commit object.
+ * @param {string} treeHash - Hash of the tree object to commit
+ * @param {string} message - Commit message to store in the commit object
+ * @param {string|string[]|null} [parentHash=null] - Parent commit hash or hashes, if any
+ * @returns {string} Hash of the stored commit object
+ * @throws {Error} If the tree hash or commit message is missing
+ */
 function commitTree(treeHash, message, parentHash = null) {
     //  1. Validate inputs
     if (!treeHash) {

--- a/src/commands/commit.js
+++ b/src/commands/commit.js
@@ -96,6 +96,13 @@ function writeTreeFromIndex(entries, prefix='') {
 
 
 
+/**
+ * Creates a commit from the current index and advances the current branch reference.
+ * Uses the existing branch tip as the parent commit when one exists.
+ * @param {string} message - Commit message to include in the new commit
+ * @returns {string} Hash of the created commit object
+ * @throws {Error} If the message, repository, index, HEAD, or parent commit reference is invalid
+ */
 function commit(message) {
     // 1. Validate Messalge
     if(!message) {

--- a/src/commands/diff.js
+++ b/src/commands/diff.js
@@ -131,8 +131,10 @@ function diffCommits(hashA, hashB) {
 }
 
 /**
- * CLI entry point.
- * @returns {void}
+ * Prints diffs for working tree changes, staged changes, or two commits.
+ * With --cached it compares the index to HEAD; with two hashes it compares those commits.
+ * @param {string[]} [args=[]] - Diff arguments, either --cached or two commit hashes
+ * @throws {Error} If the repository is missing or a compared object is not a commit
  */
 function diff(args = []) {
     ensureRepo()
@@ -147,4 +149,3 @@ function diff(args = []) {
 }
 
 module.exports = diff 
-

--- a/src/commands/hash-object.js
+++ b/src/commands/hash-object.js
@@ -7,6 +7,14 @@ const zlib = require('zlib')
 Blob object structure
     'blob <size>\0<content>'  -*/ 
 
+/**
+ * Hashes a file as a blob object using the same header and compression format as mygit objects.
+ * Optionally writes the compressed blob into the object database.
+ * @param {string} filePath - Path of the file to hash
+ * @param {boolean} [write=true] - Whether to write the blob object to .mygit/objects
+ * @returns {string} SHA-1 hash of the blob object
+ * @throws {Error} If the file path is missing or the file does not exist
+ */
 function hashObject(filePath, write=true) {
     if (!filePath) {
         console.error('Error: No file path provided');

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,6 +1,12 @@
 const fs = require('fs')
 const path = require('path')
 
+/**
+ * Creates the .mygit directory structure and initial HEAD file in the target directory.
+ * If the repository already exists, it reports that and leaves the directory unchanged.
+ * @param {string} [targetDir=process.cwd()] - Directory where the .mygit repository should be created
+ * @throws {Error} If repository initialisation fails
+ */
 function mygitInit(targetDir=process.cwd()) {
     const mygitDir = path.join(targetDir, ".mygit")
     const objectsDir = path.join(mygitDir, "objects")

--- a/src/commands/inspect-object.js
+++ b/src/commands/inspect-object.js
@@ -40,6 +40,12 @@ function parseObject(buffer) {
         console.log(content.toString())
     }
 }
+/**
+ * Decompresses a stored object and prints its type, size, and parsed content.
+ * Tree objects are displayed entry by entry with mode, name, and hash.
+ * @param {string} hash - Full object hash to inspect
+ * @throws {Error} If the hash is missing, the object is not found, or decompression fails
+ */
 function inspectObject(hash) {
 
     if (!hash) {

--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -100,6 +100,12 @@ function formatCommit(hash, commit, isShort=false) {
     return output
 }
 
+/**
+ * Walks the current branch history from HEAD and prints each reachable commit.
+ * Supports an oneline display mode for compact commit output.
+ * @param {{oneline?: boolean}} [options={}] - Display options for the log output
+ * @throws {Error} If the repository or HEAD reference is invalid
+ */
 function log(options = {}) {
     // 1. Check if we're in a mygit repository
     const gitDir = path.join(process.cwd(), '.mygit')

--- a/src/commands/ls-files.js
+++ b/src/commands/ls-files.js
@@ -4,6 +4,11 @@ const path = require('path')
 const readIndex = require('../helpers/readIndex')
 const { ensureRepo } = require('../core/repository')
 
+/**
+ * Prints the staged file paths recorded in the index, sorted alphabetically.
+ * Returns silently when the index is empty or has no entries.
+ * @throws {Error} If the current directory is not a mygit repository
+ */
 function lsFiles() {
     ensureRepo()
 

--- a/src/commands/stash.js
+++ b/src/commands/stash.js
@@ -9,6 +9,12 @@ const {
     stashShow
 } = require('../core/stash')
 
+/**
+ * Dispatches stash subcommands for saving, listing, applying, popping, dropping, clearing, or showing stashes.
+ * With no subcommand, saves the current working tree as a default WIP stash.
+ * @param {string[]} args - Stash subcommand arguments, including optional messages or stash references
+ * @throws {Error} If the repository is missing or a stash reference is malformed
+ */
 function stash(args) {
     ensureRepo()
     const cmd = args[0]

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -79,6 +79,11 @@ function getWorkingDirectoryFiles(baseDir = process.cwd(), currentDir = process.
     return files
 }
 
+/**
+ * Prints the current branch and summarises staged, unstaged, and untracked file changes.
+ * Handles both repositories with no commits yet and repositories with an existing HEAD commit.
+ * @throws {Error} If the repository is missing or the current commit cannot be read
+ */
 function status() {
     // 1. Check if in a mygit repo
 

--- a/src/commands/tag.js
+++ b/src/commands/tag.js
@@ -137,6 +137,12 @@ function parseArgs(args) {
     return { opts, positional }
 }
 
+/**
+ * Lists tags, creates a lightweight tag, or deletes an existing tag reference.
+ * Tag targets may be the current commit, a branch or tag name, or a full commit hash.
+ * @param {string[]} args - Tag flags and positional arguments
+ * @throws {Error} If the repository, tag name, target ref, or delete request is invalid
+ */
 function tag(args) {
     ensureRepo()
 

--- a/src/commands/write-tree.js
+++ b/src/commands/write-tree.js
@@ -39,20 +39,10 @@ function getMode(filePath, stats) {
 
 
 /**
- * Write a tree object to disk.
- *
- * A tree object is a Git object that stores a hierarchical directory
- * structure. It is used to represent the files and directories in a
- * repository.
- *
- * This function takes a directory path as an argument and recursively
- * traverses the directory, creating tree entries for each file and
- * directory. The tree entries are concatenated into a single byte
- * array, which is then hashed and stored as a tree object in the
- * .mygit/objects directory.
- *
- * @param {string} dir the directory path to write the tree object for
- * @returns {string} the hash of the tree object
+ * Recursively writes the directory contents as tree and blob objects.
+ * Returns the hash of the tree object representing the requested directory.
+ * @param {string} [dir=process.cwd()] - Directory path to convert into a tree object
+ * @returns {string} Hash of the stored tree object
  */
 function writeTree(dir=process.cwd()) {
     // ─── STEP 1: Read directory contents ────────────────────────────────────────


### PR DESCRIPTION
## What changed

Adds a JSDoc block to each main exported command function across all 16 files in `src/commands/` (the function bound at `module.exports = X`). Each block includes a short description, `@param` entries, `@returns` where the function returns a value, and `@throws` where the function raises or `process.exit(1)`s.

Style follows the existing JSDoc on helper functions in `diff.js` — concise (1-2 sentence descriptions), focused on parameter and return semantics, no redundant prose.

The pre-existing verbose JSDoc on `writeTree` was rewritten to match the same concise style as the rest. If you'd rather keep the longer version on writeTree, happy to revert just that one.

Closes #17

## Why

Per the issue's acceptance criteria — only documents the main function in each file (helpers were left untouched), each block lists params/returns/throws, and the renderable JSDoc supports the IDE-tooltip use case the issue calls out.

## Files changed

- `src/commands/`: `add.js`, `branch.js`, `cat-file.js`, `checkout.js`, `commit-tree.js`, `commit.js`, `diff.js`, `hash-object.js`, `init.js`, `inspect-object.js`, `log.js`, `ls-files.js`, `stash.js`, `status.js`, `tag.js`, `write-tree.js`

## Verification

`node -c src/commands/<file>.js` is clean for all 16 files (no syntax errors). No function signatures or bodies were modified — JSDoc blocks only.
