### PR TITLE
feat(ignore): implement --remove <pattern> for ignore command

### DIFF
--- a/src/commands/ignore.js
+++ b/src/commands/ignore.js
@@ -1,8 +1,6 @@
 const path = require('path')
 const fs = require('fs')
 
-const logger = require('../utils/logger')
-
 const { ensureRepo } = require('../core/repository')
 
 function getMygitignorePath() {
@@ -14,9 +12,6 @@ function ensureMygitignoreFile() {
 
     const fd = fs.openSync(mygitignorePath, 'a') 
     fs.closeSync(fd)
-    // if (!fs.existsSync(mygitignorePath)) {
-    //     fs.writeFileSync(mygitignorePath, '')
-    // }
 }
 
 function writeToMygitignoreFile(filename) {
@@ -52,8 +47,33 @@ function listPatternsInFile() {
     }
 }
 
-function removePatternFromFile(filename) {
-    throw new Error('Not implemented yet')
+function removePatternFromFile(pattern) {
+    if (!pattern) {
+        console.log(`usage: mygit ignore --remove <pattern>`)
+        return
+    }
+
+    const mygitignorePath = getMygitignorePath()
+    const content = fs.readFileSync(mygitignorePath, 'utf-8')
+    const lines = content.split('\n')
+
+    const target = pattern.trim()
+    let found = false
+    const remaining = lines.filter(line => {
+        if (line.trim() === target) {
+            found = true
+            return false
+        }
+        return true
+    })
+
+    if (!found) {
+        console.log(`pattern '${target}' not found in .mygitignore`)
+        return
+    }
+
+    fs.writeFileSync(mygitignorePath, remaining.join('\n'))
+    console.log(`pattern '${target}' removed from .mygitignore`)
 }
 
 function removeAllPatternsFromFile() {


### PR DESCRIPTION
## Description

Implements the `--remove <pattern>` functionality for the `ignore` command. This allows users to remove individual patterns from `.mygitignore` without affecting other tracked patterns.

## Related Issue

Closes #40

## Changes Made

* Implement `removePatternFromFile` to delete a single pattern from `.mygitignore`
* Add validation for missing pattern argument (shows usage hint)
* Add error message when pattern is not found in `.mygitignore`
* Remove unused `logger` import that was causing a `MODULE_NOT_FOUND` error

## Screenshots / Output

```
$ mygit ignore --remove ".env"
pattern '.env' removed from .mygitignore

$ mygit ignore --list
Patterns tracked by '.mygitignore'
- node_modules
- dist

$ mygit ignore --remove "nonexistent"
pattern 'nonexistent' not found in .mygitignore

$ mygit ignore --remove
usage: mygit ignore --remove <pattern>
```

## Checklist

* [x] Code builds and runs correctly
* [x] I tested my changes
* [x] I followed the project structure
* [x] I added/updated necessary documentation
* [x] Linked issue is included
* [x] No sensitive data (e.g. API keys) is exposed
* [x] If linked to an issue, I followed the steps to reproduce and verified the fix