### PR TITLE
feat(rm): add rm command for unstaging and removing files

### DIFF
--- a/bin/mygit.js
+++ b/bin/mygit.js
@@ -13,6 +13,10 @@ const commands = {
         modulePath: path.join(__dirname, '..', 'src', 'commands', 'add'),
         handler: function(args) { require(this.modulePath) (args) }
     },
+    'rm': {
+        modulePath: path.join(__dirname, '..', 'src', 'commands', 'rm'),
+        handler: function(args) { require(this.modulePath) (args) }
+    },
     'commit': {
         modulePath: path.join(__dirname, '..', 'src', 'commands', 'commit'),
         handler: function (args) {

--- a/src/commands/rm.js
+++ b/src/commands/rm.js
@@ -1,0 +1,70 @@
+const fs = require('fs')
+const path = require('path')
+
+const { readIndex, writeIndex } = require('../core/index')
+const { ensureRepo } = require('../core/repository')
+
+function normalizePath(filePath) {
+    // Normialize path to use foward slashes
+
+    const repoRoot = process.cwd()
+    const absolutePath = path.resolve(filePath)
+
+    // Get relative path
+    let relativePath = path.relative(repoRoot, absolutePath)
+
+    // Convert to foward slashes
+    const modifiedPath = relativePath.split(path.sep).join('/')
+
+    return modifiedPath
+}
+
+function removeFile(index, filePath, options) {
+    const normalizedPath = normalizePath(filePath)
+
+    if (!index.entries[normalizedPath]) {
+        console.error(`fatal: pathspec '${filePath}' did not match any files`)
+        return
+    }
+
+    delete index.entries[normalizedPath]
+
+    if (!options.cached) {
+        const absolutePath = path.resolve(filePath)
+
+        if (fs.existsSync(absolutePath)) {
+            const stats = fs.lstatSync(absolutePath)
+
+            if (!stats.isDirectory()) {
+                fs.unlinkSync(absolutePath)
+            }
+        }
+    }
+}
+
+function rm(args) {
+    ensureRepo()
+
+    if (args.length === 0) {
+        console.error('Nothing specified, nothing removed.')
+        return
+    }
+
+    const cached = args.includes('--cached')
+    const files = args.filter(arg => arg !== '--cached')
+
+    if (files.length === 0) {
+        console.error('Nothing specified, nothing removed.')
+        return
+    }
+
+    const index = readIndex()
+
+    for (const filePath of files) {
+        removeFile(index, filePath, { cached })
+    }
+
+    writeIndex(index)
+}
+
+module.exports = rm

--- a/tests/rm.test.js
+++ b/tests/rm.test.js
@@ -1,0 +1,88 @@
+const fs = require('fs')
+const path = require('path')
+const test = require('node:test')
+const assert = require('node:assert')
+
+const add = require('../src/commands/add')
+const rm = require('../src/commands/rm')
+const captureOutput = require('./helpers/captureOutput')
+const { cleanupRepo, baseDir, setupRepo } = require('./helpers/setup')
+
+function readIndex() {
+    const indexPath = path.join(baseDir, '.mygit', 'index')
+    return JSON.parse(fs.readFileSync(indexPath, 'utf-8'))
+}
+
+test.beforeEach(() => {
+    setupRepo()
+
+    fs.writeFileSync(
+        path.join(baseDir, '.mygit', 'index'),
+        JSON.stringify({ version: 1, entries: {} }, null, 2)
+    )
+})
+
+test.afterEach(cleanupRepo)
+
+// ____TESTS____
+
+console.log('\nTESTING RM\n')
+
+test('rm removes a staged file from index and working tree', () => {
+    fs.writeFileSync('file.txt', 'hello world')
+
+    add(['file.txt'])
+    rm(['file.txt'])
+
+    const index = readIndex()
+
+    assert.strictEqual(index.entries['file.txt'], undefined)
+    assert.strictEqual(fs.existsSync(path.join(baseDir, 'file.txt')), false)
+})
+
+test('rm --cached removes a staged file from index but leaves working tree', () => {
+    fs.writeFileSync('cached.txt', 'cached content')
+
+    add(['cached.txt'])
+    rm(['--cached', 'cached.txt'])
+
+    const index = readIndex()
+
+    assert.strictEqual(index.entries['cached.txt'], undefined)
+    assert.strictEqual(fs.existsSync(path.join(baseDir, 'cached.txt')), true)
+})
+
+test('rm of unstaged file prints fatal pathspec error', () => {
+    fs.writeFileSync('unstaged.txt', 'not staged')
+
+    const { output, exitCode } = captureOutput(() => {
+        rm(['unstaged.txt'])
+    }, true)
+
+    assert.strictEqual(output, "fatal: pathspec 'unstaged.txt' did not match any files")
+    assert.strictEqual(exitCode, null)
+})
+
+test('rm with no args prints nothing specified hint', () => {
+    const { output, exitCode } = captureOutput(() => {
+        rm([])
+    }, true)
+
+    assert.strictEqual(output, 'Nothing specified, nothing removed.')
+    assert.strictEqual(exitCode, null)
+})
+
+test('rm with multiple paths removes each entry', () => {
+    fs.writeFileSync('a.txt', 'A')
+    fs.writeFileSync('b.txt', 'B')
+
+    add(['a.txt', 'b.txt'])
+    rm(['a.txt', 'b.txt'])
+
+    const index = readIndex()
+
+    assert.strictEqual(index.entries['a.txt'], undefined)
+    assert.strictEqual(index.entries['b.txt'], undefined)
+    assert.strictEqual(fs.existsSync(path.join(baseDir, 'a.txt')), false)
+    assert.strictEqual(fs.existsSync(path.join(baseDir, 'b.txt')), false)
+})


### PR DESCRIPTION
Adds `mygit rm` which mirrors `git rm` semantics at the level this repo supports.

- `mygit rm <file>` removes from the index AND from the working tree.
- `mygit rm --cached <file>` removes from the index only; the working file stays on disk.
- Multiple paths in one invocation each remove their entry, with a single index write at the end.
- Path normalization matches `add` (resolve relative to repo root, forward slashes).

Error messages mirror `add`'s wording:

- Unstaged path: `fatal: pathspec '<file>' did not match any files`.
- No args (or only `--cached`): `Nothing specified, nothing removed.`

Wired into `bin/mygit.js` next to `add`.

### Tests

`tests/rm.test.js` adds five tests:

- rm removes a staged file from index and from the working tree.
- rm --cached removes from index but leaves the working file on disk.
- rm of an unstaged file emits the fatal pathspec error and does not throw.
- rm with no args emits the "Nothing specified" hint.
- rm with multiple paths removes each entry.

`npm test`: 140 passed (5 new + 135 existing).

Closes #10.
