### PR TITLE
add errors module

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,50 @@
+class RepositoryNotFoundError extends Error {
+  constructor() {
+    super('fatal: not a mygit repository')
+    this.name = 'RepositoryNotFoundError'
+  }
+}
+
+class ObjectNotFoundError extends Error {
+  constructor(hash) {
+    super(`Object not found: ${hash}`)
+    this.name = 'ObjectNotFoundError'
+  }
+}
+
+class InvalidObjectError extends Error {
+  constructor(message = 'Invalid or malformed object') {
+    super(message)
+    this.name = 'InvalidObjectError'
+  }
+}
+
+class InvalidReferenceError extends Error {
+  constructor(message = 'Invalid reference or ref format') {
+    super(message)
+    this.name = 'InvalidReferenceError'
+  }
+}
+
+class IndexFormatError extends Error {
+  constructor(message = 'Invalid or corrupted index file format') {
+    super(message)
+    this.name = 'IndexFormatError'
+  }
+}
+
+class ValidationError extends Error {
+  constructor(message = 'Validation failed for input or arguments') {
+    super(message)
+    this.name = 'ValidationError'
+  }
+}
+
+module.exports = {
+  RepositoryNotFoundError,
+  ObjectNotFoundError,
+  InvalidObjectError,
+  InvalidReferenceError,
+  IndexFormatError,
+  ValidationError
+}


### PR DESCRIPTION
## Description

Add centralized custom error module `src/errors.js` as part of the core refactor.

## Related Issue

Closes #48

## Changes Made

* Created `src/errors.js` with standardized custom errors
* Implemented all required error types
* Errors are lightweight, generic, and follow project architecture
* No business logic included

## Checklist

* [x] Code builds and runs correctly
* [x] I tested my changes
* [x] I followed the project structure
* [ ] I added/updated necessary documentation
* [x] Linked issue is included
* [x] No sensitive data exposed
* [x] Followed all architectural rules