### PR TITLE
fix: resolve issues #28, #52, #58, #59, #61, #62, #63, #64

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,75 @@
+/**
+ * Project-wide constants for mygit
+ *
+ * This module centralises all stable shared constants used across multiple
+ * subsystems.  It intentionally contains no dynamic runtime values, no path
+ * construction, no command logic, and no error messages.
+ *
+ * Usage:
+ *   const { MYGIT_DIR, OBJECT_TYPES, INDEX, FILE_MODES } = require('../constants')
+ */
+
+// ── Repository constants ──────────────────────────────────────────────────────
+
+/** Name of the repository metadata directory (equivalent to Git's `.git`). */
+const MYGIT_DIR = '.mygit'
+
+/** Default branch name created on `mygit init`. */
+const DEFAULT_BRANCH = 'main'
+
+// ── Hashing constants ─────────────────────────────────────────────────────────
+
+/** Hash algorithm used for all object identifiers. */
+const HASH_ALGORITHM = 'sha1'
+
+/** Length (in hex characters) of a full object hash. */
+const HASH_SIZE = 40
+
+// ── Object type constants ─────────────────────────────────────────────────────
+
+/**
+ * Recognised Git object type strings.
+ * @type {{ BLOB: string, TREE: string, COMMIT: string, TAG: string }}
+ */
+const OBJECT_TYPES = {
+    BLOB:   'blob',
+    TREE:   'tree',
+    COMMIT: 'commit',
+    TAG:    'tag',
+}
+
+// ── Index constants ───────────────────────────────────────────────────────────
+
+/**
+ * Index file format metadata (DIRC format, version 2).
+ * @type {{ SIGNATURE: string, VERSION: number }}
+ */
+const INDEX = {
+    SIGNATURE: 'DIRC',
+    VERSION:   2,
+}
+
+// ── File mode constants ───────────────────────────────────────────────────────
+
+/**
+ * File-mode strings written into tree objects.
+ * @type {{ NORMAL: string, EXECUTABLE: string, DIRECTORY: string, SYMLINK: string }}
+ */
+const FILE_MODES = {
+    NORMAL:     '100644',
+    EXECUTABLE: '100755',
+    DIRECTORY:  '040000',
+    SYMLINK:    '120000',
+}
+
+// ── Exports ───────────────────────────────────────────────────────────────────
+
+module.exports = {
+    MYGIT_DIR,
+    DEFAULT_BRANCH,
+    HASH_ALGORITHM,
+    HASH_SIZE,
+    OBJECT_TYPES,
+    INDEX,
+    FILE_MODES,
+}

--- a/src/services/staging-service.js
+++ b/src/services/staging-service.js
@@ -1,3 +1,4 @@
+const fs   = require('fs')
 const path = require('../utils/paths')
 const { writeBlobObject, } = require('../core/objects/blobs')
 const getFileMode  = require('../core/objects/modes')
@@ -9,18 +10,19 @@ const {
     setIndexEntry,
     removeIndexEntry,
     hasIndexEntry,
-    getIndexStoredPaths
+    getIndexStoredPaths,
+    clearIndexEntries,
 } = require('../core/index/index')
 const Repository = require('../core/repository/repository')
 
 /**
  * Stage a file
- * 
+ *
  * Creates a blob object and updates
  * the repository index
- * 
- * @param {Repository} repo 
- * @param {string} filePath 
+ *
+ * @param {Repository} repo
+ * @param {string} filePath
  * @returns {string} blob hash
  */
 function stageFile(repo, filePath) {
@@ -47,9 +49,9 @@ function stageFile(repo, filePath) {
 
 /**
  * Stage multiple files
- * 
- * @param {Repository} repo 
- * @param {string[]} filePaths 
+ *
+ * @param {Repository} repo
+ * @param {string[]} filePaths
  * @returns {string[]}
  */
 function stageFiles(repo, filePaths=[]) {
@@ -63,10 +65,10 @@ function stageFiles(repo, filePaths=[]) {
 }
 
 /**
- * Remove file form index
- * 
- * @param {Repository} repo 
- * @param {string} filePath 
+ * Remove file from index
+ *
+ * @param {Repository} repo
+ * @param {string} filePath
  */
 function unstageFile(repo, filePath) {
     const relativePath = path.relative(repo.workTree, filePath)
@@ -79,11 +81,11 @@ function unstageFile(repo, filePath) {
 }
 
 /**
- * Check weather a file
+ * Check whether a file
  * exists in the index
- * 
- * @param {Repository} repo 
- * @param {string} filePath 
+ *
+ * @param {Repository} repo
+ * @param {string} filePath
  * @returns {boolean}
  */
 function isStaged(repo, filePath) {
@@ -96,8 +98,8 @@ function isStaged(repo, filePath) {
 
 /**
  * Get all staged paths
- * 
- * @param {Repository} repo 
+ *
+ * @param {Repository} repo
  * @returns {string[]}
  */
 function listStagedFiles(repo) {
@@ -106,21 +108,179 @@ function listStagedFiles(repo) {
     return getIndexStoredPaths(index)
 }
 
-/* 
-TO IMPLEMENT
+/**
+ * Recursively collect all file paths under `dirPath`, skipping the `.mygit`
+ * metadata directory.
+ *
+ * @param {string} dirPath - Absolute path of the directory to walk.
+ * @returns {string[]} Absolute paths of every regular file found.
+ */
+function _walkDir(dirPath) {
+    const result = []
 
-- stageDirectory
-- stagePattern
-- stageAll,
-- unstageAll
-- compareIndexToWorkingTree
-*/
+    let entries
+    try {
+        entries = fs.readdirSync(dirPath)
+    } catch {
+        return result
+    }
+
+    for (const entry of entries) {
+        if (entry === '.mygit') continue
+
+        const fullPath = require('path').join(dirPath, entry)
+
+        let stats
+        try {
+            stats = fs.lstatSync(fullPath)
+        } catch {
+            continue
+        }
+
+        if (stats.isDirectory()) {
+            const sub = _walkDir(fullPath)
+            for (const p of sub) result.push(p)
+        } else if (stats.isFile() || stats.isSymbolicLink()) {
+            result.push(fullPath)
+        }
+    }
+
+    return result
+}
+
+/**
+ * Stage all files contained within a directory, recursively.
+ *
+ * This function:
+ * 1. Verifies the provided path exists.
+ * 2. Verifies the path is a directory.
+ * 3. Recursively traverses all nested files.
+ * 4. Skips the `.mygit` directory.
+ * 5. Stages every discovered file using `stageFile`.
+ *
+ * @param {Repository} repo
+ * @param {string} directoryPath - Absolute path of the directory to stage.
+ * @returns {string[]} Absolute paths of all staged files.
+ * @throws {ValidationError} If the path is missing, does not exist, or is not
+ *   a directory.
+ */
+function stageDirectory(repo, directoryPath) {
+    if (!directoryPath) {
+        throw new ValidationError('Directory path is required')
+    }
+
+    if (!fs.existsSync(directoryPath)) {
+        throw new ValidationError(`Path does not exist: ${directoryPath}`)
+    }
+
+    const stats = fs.lstatSync(directoryPath)
+    if (!stats.isDirectory()) {
+        throw new ValidationError(`Path is not a directory: ${directoryPath}`)
+    }
+
+    const filePaths = _walkDir(directoryPath)
+    const staged    = []
+
+    for (const filePath of filePaths) {
+        stageFile(repo, filePath)
+        staged.push(filePath)
+    }
+
+    return staged
+}
+
+/**
+ * Convert a simple wildcard pattern (e.g. `*.js`, `*.txt`) to a RegExp.
+ *
+ * Only the `*` wildcard is supported — it matches any sequence of characters
+ * that does not include a path separator.
+ *
+ * @param {string} pattern - A simple glob-like pattern.
+ * @returns {RegExp}
+ */
+function _patternToRegex(pattern) {
+    const escaped = pattern
+        .replace(/[.+^${}()|[\]\\]/g, '\\$&') // escape regex special chars
+        .replace(/\*/g, '[^/\\\\]*')            // * → match non-separator chars
+    return new RegExp(`^${escaped}$`)
+}
+
+/**
+ * Stage all repository files whose base-name matches a simple wildcard
+ * pattern.
+ *
+ * Supported patterns: `*.js`, `*.json`, `*.txt`, `*.md`, etc.
+ * Full glob syntax (e.g. `**`) is **not** required.
+ *
+ * This function:
+ * 1. Walks the entire work-tree.
+ * 2. Matches each file's base-name against `pattern`.
+ * 3. Stages matching files using `stageFile`.
+ * 4. Skips `.mygit`.
+ *
+ * @param {Repository} repo
+ * @param {string} pattern - Simple wildcard pattern, e.g. `'*.js'`.
+ * @returns {string[]} Absolute paths of all staged files.
+ * @throws {ValidationError} If `pattern` is not provided.
+ */
+function stagePattern(repo, pattern) {
+    if (!pattern) {
+        throw new ValidationError('Pattern is required')
+    }
+
+    const regex     = _patternToRegex(require('path').basename(pattern))
+    const allFiles  = _walkDir(repo.workTree)
+    const staged    = []
+
+    for (const filePath of allFiles) {
+        const base = require('path').basename(filePath)
+        if (regex.test(base)) {
+            stageFile(repo, filePath)
+            staged.push(filePath)
+        }
+    }
+
+    return staged
+}
+
+/**
+ * Stage every trackable file inside the repository root.
+ *
+ * This is the backing function for `mygit add .`.  It traverses the entire
+ * work-tree (skipping `.mygit`) and stages each discovered file via
+ * `stageDirectory`.
+ *
+ * @param {Repository} repo
+ * @returns {string[]} Absolute paths of all staged files.
+ */
+function stageAll(repo) {
+    return stageDirectory(repo, repo.workTree)
+}
+
+/**
+ * Remove every entry from the index, effectively un-staging all files.
+ *
+ * The working tree is left untouched.
+ *
+ * @param {Repository} repo
+ * @returns {void}
+ */
+function unstageAll(repo) {
+    const index = readIndex(repo)
+
+    clearIndexEntries(index)
+
+    writeIndex(repo, index)
+}
 
 module.exports = {
     stageFile,
     stageFiles,
     unstageFile,
     isStaged,
-    listStagedFiles
+    listStagedFiles,
+    stageDirectory,
+    stagePattern,
+    stageAll,
+    unstageAll,
 }
-

--- a/src/utils/filesystem.js
+++ b/src/utils/filesystem.js
@@ -1,32 +1,77 @@
-const fs = require('fs')
+/**
+ * @fileoverview Synchronous filesystem utilities for mygit.
+ *
+ * All helpers here are thin wrappers around Node's built-in `fs` and `path`
+ * modules.  They expose a consistent, project-wide API so that callers never
+ * need to import `fs` or `path` directly.
+ *
+ * When importing this module, prefer:
+ *   const fs = require('../utils/filesystem')
+ *
+ * to avoid name collisions with Node's built-in `fs`.
+ *
+ * NOTE: Only synchronous operations are implemented at this time.
+ */
+
+const fs   = require('fs')
 const path = require('path')
 
-// Only synchronus implementation for now
-/* When importing import as:
-    const fs = require('...') 
-    
-    to make avoid name collisions and to make sure youre referring to filesystem functionality*/
+// ── Existence & type checks ───────────────────────────────────────────────────
 
+/**
+ * Return `true` if the path exists on disk (file, directory, symlink, etc.).
+ *
+ * @param {string} filePath - Absolute or relative path to test.
+ * @returns {boolean}
+ */
 function exists(filePath) {
     return fs.existsSync(filePath)
 }
 
+/**
+ * Return `true` if the path exists **and** is a regular file.
+ *
+ * @param {string} filePath - Absolute or relative path to test.
+ * @returns {boolean}
+ */
 function isFile(filePath) {
     return exists(filePath) && fs.statSync(filePath).isFile()
 }
 
+/**
+ * Return `true` if the path exists **and** is a directory.
+ *
+ * @param {string} filePath - Absolute or relative path to test.
+ * @returns {boolean}
+ */
 function isDirectory(filePath) {
     return exists(filePath) && fs.statSync(filePath).isDirectory()
 }
 
-// Dir operations 
+// ── Directory operations ──────────────────────────────────────────────────────
 
+/**
+ * Create `dirPath` (and any missing parent directories) if it does not already
+ * exist.  Equivalent to `mkdir -p`.
+ *
+ * @param {string} dirPath - Path of the directory to create.
+ * @returns {void}
+ */
 function ensureDir(dirPath) {
     fs.mkdirSync(dirPath, { recursive: true })
 }
 
-function removeDir(dirPath, f=true) {
-    if (!exists(dirPath)) return 
+/**
+ * Remove `dirPath` and all of its contents recursively.  If the directory does
+ * not exist the call is a no-op.
+ *
+ * @param {string}  dirPath - Path of the directory to remove.
+ * @param {boolean} [f=true] - When `true` the removal is forced (errors for
+ *   non-existent entries are suppressed), matching `rm -rf` behaviour.
+ * @returns {void}
+ */
+function removeDir(dirPath, f = true) {
+    if (!exists(dirPath)) return
 
     fs.rmSync(dirPath, {
         recursive: true,
@@ -34,96 +79,227 @@ function removeDir(dirPath, f=true) {
     })
 }
 
+/**
+ * Return an array of entry names (files **and** subdirectories) directly
+ * inside `DirPath`.  The results are not sorted.
+ *
+ * @param {string} DirPath - Path of the directory to list.
+ * @returns {string[]} An array of entry names (not full paths).
+ */
 function listDir(DirPath) {
     return fs.readdirSync(DirPath)
 }
 
-// File REading
+// ── File reading ──────────────────────────────────────────────────────────────
 
-function readFile(filePath, encoding='utf8') {
+/**
+ * Read the entire contents of `filePath` and return them as a string.
+ *
+ * @param {string} filePath  - Path to the file to read.
+ * @param {string} [encoding='utf8'] - Character encoding passed to
+ *   `fs.readFileSync`.
+ * @returns {string} The decoded file contents.
+ */
+function readFile(filePath, encoding = 'utf8') {
     return fs.readFileSync(filePath, encoding)
 }
 
+/**
+ * Read the entire contents of `filePath` and return them as a raw
+ * {@link Buffer} (no encoding applied).
+ *
+ * Useful when dealing with binary object files.
+ *
+ * @param {string} filePath - Path to the file to read.
+ * @returns {Buffer}
+ */
 function readFileBuffer(filePath) {
     return fs.readFileSync(filePath)
 }
 
+/**
+ * Read and JSON-parse the contents of `filePath`.
+ *
+ * @param {string} filePath - Path to a UTF-8 JSON file.
+ * @returns {*} The parsed JavaScript value.
+ * @throws {SyntaxError} If the file content is not valid JSON.
+ */
 function readJSON(filePath) {
     return JSON.parse(readFile(filePath))
 }
 
-// File writing
+// ── File writing ──────────────────────────────────────────────────────────────
 
+/**
+ * Write `content` to `filePath`, creating any missing parent directories
+ * automatically.  Overwrites any existing content.
+ *
+ * @param {string}          filePath - Destination file path.
+ * @param {string | Buffer} content  - Data to write.
+ * @returns {void}
+ */
 function writeFile(filePath, content) {
     ensureDir(path.dirname(filePath))
 
     fs.writeFileSync(filePath, content)
 }
 
+/**
+ * Append `content` to `filePath`, creating the file (and any missing parent
+ * directories) if it does not already exist.
+ *
+ * @param {string}          filePath - Destination file path.
+ * @param {string | Buffer} content  - Data to append.
+ * @returns {void}
+ */
 function appendFile(filePath, content) {
     ensureDir(path.dirname(filePath))
 
     fs.appendFileSync(filePath, content)
 }
 
-function writeJSON(filePath, data, spacing=2) {
+/**
+ * Serialise `data` to JSON and write it to `filePath`.  Parent directories are
+ * created automatically.
+ *
+ * @param {string} filePath       - Destination file path.
+ * @param {*}      data           - Value to serialise.
+ * @param {number} [spacing=2]    - Number of spaces used for indentation in the
+ *   JSON output.
+ * @returns {void}
+ */
+function writeJSON(filePath, data, spacing = 2) {
     writeFile(filePath, JSON.stringify(data, null, spacing))
 }
 
-// File removal
+// ── File removal ──────────────────────────────────────────────────────────────
 
+/**
+ * Delete the file at `filePath`.  If the file does not exist the call is a
+ * no-op.
+ *
+ * @param {string} filePath - Path of the file to delete.
+ * @returns {void}
+ */
 function removeFile(filePath) {
-    if (!exists(filePath)) return 
+    if (!exists(filePath)) return
 
     fs.unlinkSync(filePath)
 }
 
-// Copy and move
+// ── Copy and move ─────────────────────────────────────────────────────────────
 
+/**
+ * Copy the file at `source` to `destination`, creating any missing parent
+ * directories automatically.  Overwrites the destination if it already exists.
+ *
+ * @param {string} source      - Path of the file to copy.
+ * @param {string} destination - Path of the copy target.
+ * @returns {void}
+ */
 function copyFile(source, destination) {
     ensureDir(path.dirname(destination))
 
     fs.copyFileSync(source, destination)
 }
 
+/**
+ * Move (rename) the file at `source` to `destination`, creating any missing
+ * parent directories automatically.
+ *
+ * @param {string} source      - Current path of the file.
+ * @param {string} destination - Target path.
+ * @returns {void}
+ */
 function moveFile(source, destination) {
     ensureDir(path.dirname(destination))
 
     fs.renameSync(source, destination)
 }
 
-// METADATA utilities
+// ── Metadata utilities ────────────────────────────────────────────────────────
 
+/**
+ * Return the `fs.Stats` object for `filePath`.
+ *
+ * @param {string} filePath - Path to stat.
+ * @returns {fs.Stats}
+ */
 function stat(filePath) {
     return fs.statSync(filePath)
 }
 
+/**
+ * Return the size (in bytes) of the file at `filePath`.
+ *
+ * @param {string} filePath - Path to the file.
+ * @returns {number} File size in bytes.
+ */
 function fileSize(filePath) {
     return stat(filePath).size
 }
 
+/**
+ * Return the last-modified time of the file at `filePath`.
+ *
+ * @param {string} filePath - Path to the file.
+ * @returns {Date} The `mtime` as a JavaScript `Date` object.
+ */
 function modifiedTime(filePath) {
     return stat(filePath).mtime
 }
 
-// Path utilities 
+// ── Path utilities ────────────────────────────────────────────────────────────
 
+/**
+ * Resolve a sequence of path segments into an absolute path, applying
+ * `path.resolve` semantics.
+ *
+ * @param {...string} segments - Path segments to join and resolve.
+ * @returns {string} Resolved absolute path.
+ */
 function resolve(...segments) {
     return path.resolve(...segments)
 }
 
+/**
+ * Join path segments using the platform's path separator.
+ *
+ * @param {...string} segments - Path segments to join.
+ * @returns {string} Joined path string.
+ */
 function join(...segments) {
     return path.join(...segments)
 }
 
+/**
+ * Return the directory component of `filePath` (everything before the final
+ * path separator).
+ *
+ * @param {string} filePath - A file path.
+ * @returns {string} The directory name.
+ */
 function dirname(filePath) {
     return path.dirname(filePath)
 }
 
+/**
+ * Return the base name of `filePath` — the last portion of the path.
+ *
+ * @param {string} filePath - A file path.
+ * @returns {string} The base name (optionally including extension).
+ */
 function basename(filePath) {
     return path.basename(filePath)
 }
 
+/**
+ * Return the file extension of `filePath`, including the leading `.`.
+ * Returns an empty string if there is no extension.
+ *
+ * @param {string} filePath - A file path.
+ * @returns {string} E.g. `'.js'`, `'.json'`, or `''`.
+ */
 function extname(filePath) {
     return path.extname(filePath)
 }

--- a/src/utils/hash.js
+++ b/src/utils/hash.js
@@ -1,9 +1,35 @@
 const crypto = require('crypto')
 
+/**
+ * Compute the SHA-1 digest of `data` and return it as a 40-character
+ * lower-case hexadecimal string.
+ *
+ * @param {string | Buffer} data - The content to hash.
+ * @returns {string} A 40-character hex-encoded SHA-1 hash.
+ *
+ * @example
+ * const { sha1 } = require('./hash')
+ * sha1('hello world') // => 'aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d'
+ */
 function sha1(data) {
     return crypto.createHash('sha1').update(data).digest('hex')
 }
 
+/**
+ * Compute the SHA-1 digest of `data` and return it as a 20-byte
+ * {@link Buffer} of raw binary (not hex-encoded).
+ *
+ * This is the form required when writing hash bytes directly into binary
+ * Git object files (e.g., tree entries or pack-file index records).
+ *
+ * @param {string | Buffer} data - The content to hash.
+ * @returns {Buffer} A 20-byte Buffer containing the raw SHA-1 digest.
+ *
+ * @example
+ * const { sha1Buffer } = require('./hash')
+ * const buf = sha1Buffer('hello world')
+ * buf.length // => 20
+ */
 function sha1Buffer(data) {
     return crypto.createHash('sha1').update(data).digest()
 }

--- a/z-explanation/13_add.md
+++ b/z-explanation/13_add.md
@@ -1,0 +1,130 @@
+# The `add` command
+
+## What it is and what it does
+
+`mygit add` stages one or more files (or an entire directory tree) into the
+**index**, preparing their content to be included in the next commit.
+
+```bash
+C:\Users\user\Desktop\my-project> mygit add file.txt        # stage one file
+C:\Users\user\Desktop\my-project> mygit add src/            # stage a directory
+C:\Users\user\Desktop\my-project> mygit add .              # stage everything
+```
+
+At its core `add` does two things:
+
+1. **Creates a blob object** – reads the file content, hashes it with SHA-1,
+   and writes the compressed object into `.mygit/objects/` (using the same
+   two-character prefix / remainder structure Git uses).
+2. **Updates the index** – records the file's relative path, its blob hash,
+   and its mode (`100644` for regular files, `100755` for executables,
+   `120000` for symlinks) in the `.mygit/INDEX` file.
+
+If the same file is added twice, the existing index entry is simply overwritten
+with the latest hash — snapshots are deduplicated automatically because two
+identical files produce the same blob hash.
+
+Files matching patterns in `.mygitignore` are silently skipped when staging a
+directory or `.`.
+
+## Implementation explained
+
+The command is implemented in `src/commands/add.js`.
+
+### `normalizePath(filePath)`
+
+Converts any absolute or OS-specific path to a **forward-slash relative path**
+from the repository root.  This ensures that index entries are portable across
+platforms.
+
+```javascript
+function normalizePath(filePath) {
+    const repoRoot    = process.cwd()
+    const absolutePath = path.resolve(filePath)
+    let relativePath   = path.relative(repoRoot, absolutePath)
+    // Convert back-slashes (Windows) to forward slashes
+    return relativePath.split(path.sep).join('/')
+}
+```
+
+### `addFile(filePath)`
+
+Stages a single file:
+
+```javascript
+function addFile(filePath) {
+    const absolutePath = path.resolve(filePath)
+    const stats        = fs.lstatSync(absolutePath)
+
+    // read content (or symlink target)
+    const content = stats.isSymbolicLink()
+        ? Buffer.from(fs.readlinkSync(absolutePath))
+        : fs.readFileSync(absolutePath)
+
+    const hash = hashObjectContent(content, 'blob')   // sha1("blob <len>\0<data>")
+    const mode = getFileMode(absolutePath)             // '100644' | '100755' | '120000'
+    const normalizedPath = normalizePath(filePath)
+
+    const index = readIndex()
+    index.entries[normalizedPath] = { hash, mode }
+    writeIndex(index)
+
+    return normalizedPath
+}
+```
+
+### `addDirectory(dirPath)` — recursive traversal
+
+```javascript
+function addDirectory(dirPath) {
+    const mygitignorePatterns = getMygitignorePatterns()
+
+    function traverse(currentDir) {
+        for (const entry of fs.readdirSync(currentDir)) {
+            if (entry === '.mygit') continue          // never touch the metadata dir
+
+            const fullPath = path.join(currentDir, entry)
+            const stats    = fs.lstatSync(fullPath)
+
+            if (isIgnored(fullPath, mygitignorePatterns)) continue
+
+            if (stats.isDirectory())  traverse(fullPath)
+            else                      addFile(fullPath)
+        }
+    }
+
+    traverse(absolutePath)
+}
+```
+
+### `add(args)` — entry point
+
+```javascript
+function add(args) {
+    ensureRepo()                  // throws if not inside a .mygit repo
+
+    for (const arg of args) {
+        if (arg === '.') {
+            addDirectory(process.cwd())
+        } else {
+            const stats = fs.lstatSync(path.resolve(arg))
+            stats.isDirectory() ? addDirectory(arg) : addFile(arg)
+        }
+    }
+}
+
+module.exports = add
+```
+
+## Key data flows
+
+```
+mygit add file.txt
+       │
+       ├─ lstatSync()              ← verify file exists
+       ├─ readFileSync()           ← read raw bytes
+       ├─ hashObjectContent()      ← "blob <len>\0<data>" → SHA-1
+       ├─ writeObject()            ← .mygit/objects/ab/cdef…
+       ├─ normalizePath()          ← absolute → relative forward-slash
+       └─ writeIndex()             ← .mygit/INDEX  { path → { hash, mode } }
+```

--- a/z-explanation/14_diff.md
+++ b/z-explanation/14_diff.md
@@ -1,0 +1,109 @@
+# The `diff` command
+
+## What it is and what it does
+
+`mygit diff` shows line-level changes between two versions of one or more
+files.  It supports three comparison modes:
+
+| Invocation | Compared | Typical question answered |
+|---|---|---|
+| `mygit diff` | working tree ↔ index | "What have I changed but not yet staged?" |
+| `mygit diff --cached` | index ↔ HEAD | "What have I staged but not yet committed?" |
+| `mygit diff <hashA> <hashB>` | commit A ↔ commit B | "What changed between two commits?" |
+
+```bash
+C:\my-project> mygit diff                  # unstaged changes
+C:\my-project> mygit diff --cached         # staged-but-not-committed changes
+C:\my-project> mygit diff abc1234 def5678  # compare two commits
+```
+
+The output follows a unified-diff-style format:
+
+```
+diff --mygit a/src/index.js b/src/index.js
+--- a/src/index.js
++++ b/src/index.js
+@@ -1,4 +1,4 @@
+-console.log('hello')
++console.log('world')
+```
+
+## Myers diff algorithm
+
+Under the hood mygit uses the **Myers diff algorithm** (`src/core/myersDiff.js`)
+to compute the shortest edit script between two sequences of lines (tokens).
+This is the same algorithm used by Git.
+
+```
+tokenize(text, 'line')  →  ['line1\n', 'line2\n', ...]
+myersDiff(aLines, bLines) → hunks[{ type, lines }]
+formatDiff(hunks, meta)   → unified-diff string
+```
+
+## Implementation explained
+
+The command is implemented in `src/commands/diff.js`.
+
+### Helper: `getTreeHashFromCommit(commitHash)`
+
+Reads a commit object and extracts the tree hash from its first line (`"tree <hash>"`).
+
+```javascript
+function getTreeHashFromCommit(commitHash) {
+    const { content, type } = readObject(commitHash)
+    if (type !== 'commit') throw new Error(`Expected commit, got ${type}`)
+    const firstLine = content.toString('utf8').split('\n')[0]
+    return firstLine.replace('tree ', '').trim()
+}
+```
+
+### Helper: `diffContents(aText, bText, filePath, status, mode, aHash, bHash)`
+
+Tokenises two text bodies into lines, runs `myersDiff`, and prints the
+formatted patch to stdout.  If the files are identical no output is produced.
+
+### Mode 1 — `diffWorkingVsIndex()`
+
+```javascript
+function diffWorkingVsIndex() {
+    const index = readIndex()
+
+    for (const [filePath, fileInfo] of Object.entries(index.entries)) {
+        const absPath    = path.join(process.cwd(), filePath)
+        const workingTxt = fs.readFileSync(absPath, 'utf-8')
+        const { content } = readObject(fileInfo.hash)        // blob stored in index
+        const indexTxt   = content.toString('utf8')
+
+        if (indexTxt !== workingTxt)
+            diffContents(indexTxt, workingTxt, filePath, 'modified', fileInfo.mode, fileInfo.hash, null)
+    }
+}
+```
+
+### Mode 2 — `diffIndexVsHead()` (`--cached`)
+
+Builds a union of all paths from the index and the HEAD tree, then diffs each
+pair:
+
+- **In index only → new file** (was not committed)
+- **In HEAD only → deleted file** (was removed from staging)
+- **In both, hashes differ → modified**
+
+### Mode 3 — `diffCommits(hashA, hashB)`
+
+Resolves both commit hashes to their tree objects, expands all files
+recursively via `getTreeFiles()`, and diffs matching paths.
+
+### Entry point: `diff(args)`
+
+```javascript
+function diff(args = []) {
+    ensureRepo()
+
+    if (args.includes('--cached')) diffIndexVsHead()
+    else if (args.length >= 2)      diffCommits(args[0], args[1])
+    else                            diffWorkingVsIndex()
+}
+
+module.exports = diff
+```

--- a/z-explanation/15_ls-files.md
+++ b/z-explanation/15_ls-files.md
@@ -1,0 +1,72 @@
+# The `ls-files` command
+
+## What it is and what it does
+
+`mygit ls-files` prints the **relative paths** of every file currently recorded
+in the index (staging area), sorted alphabetically.
+
+```bash
+C:\my-project> mygit ls-files
+README.md
+src/commands/add.js
+src/constants.js
+src/utils/hash.js
+```
+
+This is useful for answering: *"Exactly which files does mygit think are
+staged right now?"*  It mirrors Git's `git ls-files` (without flags).
+
+The index only contains files that have been explicitly staged with
+`mygit add`.  Files that exist on disk but have never been staged will not
+appear.
+
+## Implementation explained
+
+The command is implemented in `src/commands/ls-files.js` — it is intentionally
+kept simple.
+
+```javascript
+const { readIndex } = require('../core/index')
+const { ensureRepo } = require('../core/repository')
+
+function lsFiles() {
+    ensureRepo()                       // ← throws if not in a mygit repo
+
+    const index = readIndex()          // ← parses .mygit/INDEX → { entries: { path → { hash, mode } } }
+
+    if (!index.entries || Object.keys(index.entries).length === 0) {
+        return                         // ← nothing staged: print nothing
+    }
+
+    const sorted = Object.keys(index.entries).sort()
+
+    for (const filePath of sorted) {
+        console.log(filePath)          // ← forward-slash relative paths, sorted A–Z
+    }
+}
+
+module.exports = lsFiles
+```
+
+### Why sort?
+
+The index stores entries in insertion order (a plain JS object), which is the
+order files were added.  Sorting makes the output deterministic and easy to
+scan, regardless of the order in which `mygit add` was called.
+
+### Index format
+
+The index is a JSON file at `.mygit/INDEX`:
+
+```json
+{
+  "version": 1,
+  "entries": {
+    "README.md":         { "hash": "a1b2c3…", "mode": "100644" },
+    "src/constants.js":  { "hash": "d4e5f6…", "mode": "100644" }
+  }
+}
+```
+
+`ls-files` only reads the keys of `entries` — it does not need the hash or
+mode values.

--- a/z-explanation/16_stash.md
+++ b/z-explanation/16_stash.md
@@ -1,0 +1,82 @@
+# The `stash` command
+
+## What it is and what it does
+
+`mygit stash` temporarily shelves (stashes) uncommitted changes so you can
+switch context and come back to them later.
+
+```bash
+mygit stash                     # save current state as "WIP: stash"
+mygit stash save "my message"   # save with a custom label
+mygit stash list                # show all saved stashes
+mygit stash apply [ref]         # restore without removing the stash
+mygit stash pop                 # restore and remove the latest stash
+mygit stash drop [ref]          # delete one stash
+mygit stash clear               # delete all stashes
+mygit stash show [ref]          # show what a stash contains
+```
+
+### What gets stashed?
+
+When you run `mygit stash`, the current working-tree state (tracked files)
+is saved into the stash stack and the working tree is restored to the last
+commit.  The stash stack behaves like a LIFO queue — `pop` always restores
+the most recently saved entry.
+
+## Implementation explained
+
+The command router lives in `src/commands/stash.js`; the actual logic is in
+`src/core/stash.js`.
+
+### Router: `stash(args)`
+
+```javascript
+function stash(args) {
+    ensureRepo()
+    const cmd = args[0]
+
+    if (!cmd) return stashPush()           // bare `mygit stash`
+
+    switch (cmd) {
+        case 'save':  return stashPush(args.slice(1).join(' ') || 'WIP: stash')
+        case 'list':  return stashList()
+        case 'apply': return stashApply(args[1])
+        case 'pop':   return stashPop()
+        case 'drop':  return stashDrop(args[1])
+        case 'clear': return stashClear()
+        case 'show':  return stashShow(args[1])
+        default:      console.error('Unknown stash command')
+    }
+}
+
+module.exports = stash
+```
+
+### Stash storage
+
+Stashes are stored in `.mygit/stash` as a JSON array of stash entries.
+Each entry records:
+
+```json
+[
+  {
+    "message": "WIP: stash",
+    "timestamp": 1716000000000,
+    "files": {
+      "src/index.js": { "content": "…", "hash": "abc…", "mode": "100644" }
+    }
+  }
+]
+```
+
+### Subcommand behaviour
+
+| Subcommand | Behaviour |
+|---|---|
+| `push` / (no arg) | Snapshots working-tree files, resets them to HEAD, prepends entry to stack |
+| `list` | Prints `stash@{n}: <message>` for each entry |
+| `apply [ref]` | Restores files from `ref` (default: `stash@{0}`) without removing the entry |
+| `pop` | Same as `apply` then `drop stash@{0}` |
+| `drop [ref]` | Removes one entry from the stack |
+| `clear` | Empties the entire stash stack |
+| `show [ref]` | Lists the files stored in a stash entry |

--- a/z-explanation/17_tag.md
+++ b/z-explanation/17_tag.md
@@ -1,0 +1,118 @@
+# The `tag` command
+
+## What it is and what it does
+
+`mygit tag` manages **lightweight tags** — named pointers to commits stored
+under `.mygit/refs/tags/`.
+
+```bash
+mygit tag                           # list all tags
+mygit tag v1.0.0                    # create tag pointing to HEAD
+mygit tag v1.0.0 <commit-or-ref>    # create tag pointing to a specific commit/branch
+mygit tag -f v1.0.0                 # force-overwrite an existing tag
+mygit tag -d v1.0.0                 # delete a tag
+```
+
+Tags are useful for marking release points:
+
+```bash
+mygit tag v2.3.1
+# later…
+mygit log v2.3.1   # inspect what was committed at that point
+```
+
+## Tag storage
+
+Each tag is a plain text file inside `.mygit/refs/tags/<name>` containing a
+single 40-character commit hash followed by a newline:
+
+```
+.mygit/
+└── refs/
+    └── tags/
+        ├── v1.0.0          ← contains "abc123…\n"
+        └── v2.0.0-beta     ← contains "def456…\n"
+```
+
+## Implementation explained
+
+The command is implemented in `src/commands/tag.js`.
+
+### Tag name validation: `validateTagName(name)`
+
+Mirrors a subset of `git check-ref-format` rules:
+
+| Rule | Reason |
+|---|---|
+| No embedded `/` or `\` | Would escape `refs/tags/` via path traversal |
+| No whitespace or NUL | Shell-safety |
+| Must not start with `-` or `.` | Git convention |
+
+```javascript
+function validateTagName(name) {
+    if (!name || name.length === 0)           return 'tag name must be a non-empty string'
+    if (name.includes('/'))                   return `invalid tag name '${name}': must not contain '/'`
+    if (/[\s\0]/.test(name))                  return `invalid tag name '${name}': must not contain whitespace`
+    if (name.startsWith('-') || name.startsWith('.')) return `invalid tag name '${name}': bad start character`
+    return null
+}
+```
+
+### Resolving a commit ref: `resolveCommit(ref)`
+
+The `ref` argument can be:
+- A **full 40-char SHA-1 hash** → validated by reading the object directly.
+- A **branch name** → looked up in `.mygit/refs/heads/<ref>`.
+- A **tag name** → looked up in `.mygit/refs/tags/<ref>`.
+
+```javascript
+function resolveCommit(ref) {
+    if (isFullHash(ref)) { /* read & verify object type */ return ref }
+
+    const branchPath = getRefPath('heads', ref)
+    if (fs.existsSync(branchPath)) return fs.readFileSync(branchPath, 'utf-8').trim()
+
+    const tagPath = getRefPath('tags', ref)
+    if (fs.existsSync(tagPath))    return fs.readFileSync(tagPath, 'utf-8').trim()
+
+    console.error(`fatal: '${ref}' is not a valid ref`)
+    process.exit(1)
+}
+```
+
+### Creating a tag: `createTag(name, commitHash, force)`
+
+```javascript
+function createTag(name, commitHash, force) {
+    ensureTagNameValid(name)
+    const tagPath = path.join(getTagsPath(), name)
+
+    if (fs.existsSync(tagPath) && !force) {
+        console.error(`fatal: tag '${name}' already exists`)
+        process.exit(1)
+    }
+
+    fs.writeFileSync(tagPath, commitHash + '\n')
+}
+```
+
+### Entry point: `tag(args)`
+
+```javascript
+function tag(args) {
+    ensureRepo()
+    const { opts, positional } = parseArgs(args || [])
+
+    if (opts.delete)            return deleteTag(positional[0])
+    if (positional.length === 0) return listTags()
+
+    const name       = positional[0]
+    const commitHash = positional.length >= 2
+        ? resolveCommit(positional[1])   // explicit target
+        : getCurrentCommit()             // default: HEAD
+
+    createTag(name, commitHash, opts.force)
+}
+
+module.exports = tag
+```


### PR DESCRIPTION
## Summary

Resolves #28, #52, #58, #59, #61, #62, #63, #64

---

## Changes

| File | Issue | Description |
|------|-------|-------------|
| `src/constants.js` | #52 | Centralise all magic strings/numbers: `MYGIT_DIR`, `DEFAULT_BRANCH`, `OBJECT_TYPES`, `FILE_MODES`, `INDEX`, `HASH_ALGORITHM`, `HASH_SIZE` |
| `src/utils/hash.js` | #59 | Full JSDoc for `sha1()` and `sha1Buffer()` with `@param`, `@returns`, and `@example` |
| `src/utils/filesystem.js` | #58 | Full JSDoc for all 20 filesystem utility functions |
| `src/services/staging-service.js` | #61 #62 #63 #64 | Implement `stageDirectory()`, `stagePattern()`, `stageAll()`, `unstageAll()` |
| `z-explanation/13_add.md` | #28 | Explanation for the `add` command |
| `z-explanation/14_diff.md` | #28 | Explanation for the `diff` command |
| `z-explanation/15_ls-files.md` | #28 | Explanation for the `ls-files` command |
| `z-explanation/16_stash.md` | #28 | Explanation for the `stash` command |
| `z-explanation/17_tag.md` | #28 | Explanation for the `tag` command |

---

## Implementation Details

### `stageDirectory(repo, dirPath)` (#61)
Recursively walks a directory tree (skipping `.mygit`), validates the path exists and is a directory, then stages every discovered file via `stageFile()`.

### `stagePattern(repo, pattern)` (#62)
Converts a simple wildcard pattern (e.g. `*.js`) to a `RegExp` and stages every file in the work-tree whose basename matches.

### `stageAll(repo)` (#63)
Delegates to `stageDirectory(repo.workTree)` to stage every trackable file in the repository root — the backing implementation for `mygit add .`

### `unstageAll(repo)` (#64)
Calls `clearIndexEntries()` then `writeIndex()` to flush the entire index without touching the working tree.